### PR TITLE
feat(#3): タスク 1.2: 基本的な型と定数の定義を完了

### DIFF
--- a/Gemini/csharp_transplant/csharp_transplant_tasks/Phase1/task_1.2_define_basic_types.md
+++ b/Gemini/csharp_transplant/csharp_transplant_tasks/Phase1/task_1.2_define_basic_types.md
@@ -34,9 +34,44 @@ MCAPライブラリ全体で共通して使用される基本的な列挙型、�
 -   `Status`, `McapWriterOptions`, `ReadMessageOptions`, `MessageView` の基本的なクラス/構造体が定義されている。
 -   プロジェクトが正常にビルドできる。
 
+## 未実装項目 (サブIssue)
+
+-   `Status` 構造体の実装 (Issue #39)
+-   `ReadMessageOptions` クラスの実装 (Issue #40)
+-   `MessageView` クラスの実装 (Issue #41)
+
 ## 参考 (C++)
 
 -   `mcap/types.hpp`
 -   `mcap/errors.hpp`
 -   `mcap/reader.hpp`
 -   `mcap/writer.hpp`
+
+## 作業状況
+
+### 手順1: `Mcap/` ディレクトリの作成
+
+- `Mcap.CSharp` プロジェクト内に `Mcap` ディレクトリを作成しました。
+
+### 手順2: `Enums.cs` の作成
+
+- `Mcap/` ディレクトリに `Enums.cs` ファイルを作成し、`OpCode`, `Compression`, `CompressionLevel` 列挙型を定義しました。
+- TDDの原則に従い、`OpCode` の値を検証するテスト (`BasicTypesTests.cs`) を作成し、成功することを確認しました。
+
+### 手順3: `Types.cs` の作成
+
+- `Mcap/` ディレクトリに `Types.cs` ファイルを作成し、`Status`, `McapWriterOptions`, `ReadMessageOptions`, `MessageView` の骨格を定義しました。
+- TDDの原則に従い、C++の実装を参考に `McapWriterOptions` の以下のプロパティを実装しました。
+    - `Profile` (string)
+    - `ChunkSize` (ulong)
+    - `Compression` (enum)
+    - `CompressionLevel` (enum)
+    - `NoChunking` (bool)
+    - `ForceCompression` (bool)
+- 各プロパティに対応するテストを `TypesTests.cs` に追加し、すべて成功することを確認しました。
+- `McapWriterOptions` の定義に、移植元であるC++の構造体名をコメントとして追記しました。
+
+### 手順4: 定数の定義
+
+- `Constants.cs` ファイルを作成し、MCAPの主要な定数（`LibraryVersion`, `SpecVersion`, `Magic`, `DefaultChunkSize`, `EndOffset`, `MaxTime`）を定義しました。
+- 各定数に対応するテストを `ConstantsTests.cs` に追加し、すべて成功することを確認しました。

--- a/csharp/Mcap.CSharp.Tests/BasicTypesTests.cs
+++ b/csharp/Mcap.CSharp.Tests/BasicTypesTests.cs
@@ -1,0 +1,13 @@
+using Mcap.CSharp.Mcap;
+
+namespace Mcap.CSharp.Tests;
+
+public class BasicTypesTests
+{
+    [Fact]
+    public void TestOpCodeValues()
+    {
+        Assert.Equal(0x01, (byte)OpCode.Header);
+        Assert.Equal(0x0F, (byte)OpCode.DataEnd);
+    }
+}

--- a/csharp/Mcap.CSharp.Tests/ConstantsTests.cs
+++ b/csharp/Mcap.CSharp.Tests/ConstantsTests.cs
@@ -1,0 +1,44 @@
+using Mcap.CSharp.Mcap;
+using Xunit;
+
+namespace Mcap.CSharp.Tests;
+
+public class ConstantsTests
+{
+    [Fact]
+    public void TestLibraryVersion()
+    {
+        Assert.Equal("2.0.2", Constants.LibraryVersion);
+    }
+
+    [Fact]
+    public void TestSpecVersion()
+    {
+        Assert.Equal('0', Constants.SpecVersion);
+    }
+
+    [Fact]
+    public void TestMagicBytes()
+    {
+        byte[] expectedMagic = { 137, 77, 67, 65, 80, (byte)Constants.SpecVersion, 13, 10 };
+        Assert.Equal(expectedMagic, Constants.Magic);
+    }
+
+    [Fact]
+    public void TestDefaultChunkSize()
+    {
+        Assert.Equal(1024UL * 768, Constants.DefaultChunkSize);
+    }
+
+    [Fact]
+    public void TestEndOffset()
+    {
+        Assert.Equal(ulong.MaxValue, Constants.EndOffset);
+    }
+
+    [Fact]
+    public void TestMaxTime()
+    {
+        Assert.Equal(ulong.MaxValue, Constants.MaxTime);
+    }
+}

--- a/csharp/Mcap.CSharp.Tests/TypesTests.cs
+++ b/csharp/Mcap.CSharp.Tests/TypesTests.cs
@@ -1,0 +1,53 @@
+using Mcap.CSharp.Mcap;
+
+namespace Mcap.CSharp.Tests;
+
+public class TypesTests
+{
+    [Fact]
+    public void CanCreateMcapWriterOptions()
+    {
+        var options = new McapWriterOptions();
+        Assert.NotNull(options);
+    }
+
+    [Fact]
+    public void McapWriterOptions_CanSetProfile()
+    {
+        var options = new McapWriterOptions { Profile = "test_profile" };
+        Assert.Equal("test_profile", options.Profile);
+    }
+
+    [Fact]
+    public void McapWriterOptions_CanSetChunkSize()
+    {
+        var options = new McapWriterOptions { ChunkSize = 1024 };
+        Assert.Equal(1024UL, options.ChunkSize);
+    }
+
+    [Fact]
+    public void McapWriterOptions_CanSetCompression()
+    {
+        var options = new McapWriterOptions { Compression = Compression.Lz4 };
+        Assert.Equal(Compression.Lz4, options.Compression);
+    }
+
+    [Fact]
+    public void McapWriterOptions_CanSetCompressionLevel()
+    {
+        var options = new McapWriterOptions { CompressionLevel = CompressionLevel.Fast };
+        Assert.Equal(CompressionLevel.Fast, options.CompressionLevel);
+    }
+
+    [Fact]
+    public void McapWriterOptions_CanSetBooleanFlags()
+    {
+        var options = new McapWriterOptions
+        {
+            NoChunking = true,
+            ForceCompression = true
+        };
+        Assert.True(options.NoChunking);
+        Assert.True(options.ForceCompression);
+    }
+}

--- a/csharp/Mcap.CSharp/Mcap/Constants.cs
+++ b/csharp/Mcap.CSharp/Mcap/Constants.cs
@@ -1,0 +1,11 @@
+namespace Mcap.CSharp.Mcap;
+
+public static class Constants
+{
+    public const string LibraryVersion = "2.0.2"; // Corresponds to MCAP_LIBRARY_VERSION
+    public const char SpecVersion = '0'; // Corresponds to SpecVersion
+    public static readonly byte[] Magic = { 137, 77, 67, 65, 80, (byte)SpecVersion, 13, 10 }; // Corresponds to Magic
+    public const ulong DefaultChunkSize = 1024 * 768; // Corresponds to DefaultChunkSize
+    public const ulong EndOffset = ulong.MaxValue; // Corresponds to EndOffset
+    public const ulong MaxTime = ulong.MaxValue; // Corresponds to MaxTime
+}

--- a/csharp/Mcap.CSharp/Mcap/Enums.cs
+++ b/csharp/Mcap.CSharp/Mcap/Enums.cs
@@ -1,0 +1,36 @@
+namespace Mcap.CSharp.Mcap;
+
+public enum OpCode : byte
+{
+    Header = 0x01,
+    Footer = 0x02,
+    Schema = 0x03,
+    Channel = 0x04,
+    Message = 0x05,
+    Chunk = 0x06,
+    MessageIndex = 0x07,
+    ChunkIndex = 0x08,
+    Attachment = 0x09,
+    AttachmentIndex = 0x0A,
+    Statistics = 0x0B,
+    Metadata = 0x0C,
+    MetadataIndex = 0x0D,
+    SummaryOffset = 0x0E,
+    DataEnd = 0x0F,
+}
+
+public enum Compression
+{
+    None,
+    Lz4,
+    Zstd,
+}
+
+public enum CompressionLevel
+{
+    Default,
+    Fastest,
+    Fast,
+    Slow,
+    Slowest,
+}

--- a/csharp/Mcap.CSharp/Mcap/Types.cs
+++ b/csharp/Mcap.CSharp/Mcap/Types.cs
@@ -1,0 +1,29 @@
+namespace Mcap.CSharp.Mcap;
+
+public readonly struct Status
+{
+    // TBD
+}
+
+/// <summary>
+/// Corresponds to the C++ `mcap::McapWriterOptions` struct.
+/// </summary>
+public class McapWriterOptions
+{
+    public string Profile { get; set; } = "";
+    public ulong ChunkSize { get; set; } = 8 * 1024 * 1024; // Default to 8MB
+    public Compression Compression { get; set; } = Compression.Zstd;
+    public CompressionLevel CompressionLevel { get; set; } = CompressionLevel.Default;
+    public bool NoChunking { get; set; } = false;
+    public bool ForceCompression { get; set; } = false;
+}
+
+public class ReadMessageOptions
+{
+    // TBD
+}
+
+public class MessageView
+{
+    // TBD
+}


### PR DESCRIPTION
このプルリクエストは、C# MCAPライブラリ移植計画の「タスク 1.2: 基本的な型と定数の定義」を完了します。

主な変更点:
- `Mcap/` ディレクトリを作成し、`Enums.cs`, `Types.cs`, `Constants.cs` を定義しました。
- `OpCode`, `Compression`, `CompressionLevel` 列挙型を定義しました。
- `McapWriterOptions` クラスにC++実装を参考にプロパティを実装しました。
- MCAPの主要な定数を定義しました。
- 各実装に対してTDDに基づきテストを作成し、成功することを確認しました。
- `task_1.2_define_basic_types.md` に作業状況を追記しました。
- 未実装項目についてサブIssueを作成し、タスクファイルに追記しました。

関連Issue: #3