### PR TITLE
feat(#4): タスク 1.3: データモデルのクラス実装を完了

### DIFF
--- a/Gemini/csharp_transplant/csharp_transplant_tasks/Phase1/task_1.3_implement_data_models.md
+++ b/Gemini/csharp_transplant/csharp_transplant_tasks/Phase1/task_1.3_implement_data_models.md
@@ -40,7 +40,41 @@ MCAPフォーマットの各レコードタイプに対応するC#のクラス�
 -   各クラスには、仕様に基づいたプロパティが定義されている。
 -   プロジェクトが正常にビルドできる。
 
+## 未実装項目 (サブIssue)
+
+
 ## 参考 (C++)
 
 -   `mcap/types.hpp`
 -   `Gemini/cpp/cpp_item_list.md`
+
+## 作業状況
+
+### 1. `Records/` ディレクトリの作成
+
+- `Mcap.CSharp/Mcap/` ディレクトリ内に `Records` ディレクトリを作成しました。
+
+### 2. 各レコードクラスの作成
+
+- `Records/` ディレクトリに、MCAPの各レコードに対応するC#クラスファイル（`Header.cs`, `Footer.cs`, `Schema.cs`, `Channel.cs`, `Message.cs`, `Chunk.cs`, `MessageIndex.cs`, `ChunkIndex.cs`, `Attachment.cs`, `AttachmentIndex.cs`, `Statistics.cs`, `Metadata.cs`, `MetadataIndex.cs`, `SummaryOffset.cs`, `DataEnd.cs`）を作成しました。この段階では、プロパティはTBDコメントのままです。
+- 各クラスの定義に、移植元であるC++の構造体名をコメントとして追記しました。
+
+### 3. プロパティの定義 (TDDによる実装)
+
+- `RecordsTests.cs` テストファイルを作成し、`Header` および `Footer` クラスの基本的なインスタンス化テストを追加しました。
+- `Header` クラスにC++の `mcap::Header` 構造体を参考に `Profile` (string) と `Library` (string) プロパティを実装しました。
+- `Footer` クラスにC++の `mcap::Footer` 構造体を参考に `SummaryStart` (ulong), `SummaryOffsetStart` (ulong), `SummaryCrc` (uint) プロパティを実装しました。
+- `Schema` クラスにC++の `mcap::Schema` 構造体を参考に `Id` (ushort), `Name` (string), `Encoding` (string), `Data` (byte[]) プロパティを実装しました。
+- `Channel` クラスにC++の `mcap::Channel` 構造体を参考に `Id` (ushort), `Topic` (string), `MessageEncoding` (string), `SchemaId` (ushort), `Metadata` (IReadOnlyDictionary<string, string>) プロパティを実装しました。
+- `Message` クラスにC++の `mcap::Message` 構造体を参考に `ChannelId` (ushort), `Sequence` (uint), `LogTime` (ulong), `PublishTime` (ulong), `Data` (byte[]) プロパティを実装しました。
+- `Chunk` クラスにC++の `mcap::Chunk` 構造体を参考に `MessageStartTime` (ulong), `MessageEndTime` (ulong), `UncompressedSize` (ulong), `UncompressedCrc` (uint), `Compression` (string), `CompressedSize` (ulong), `Records` (byte[]) プロパティを実装しました。
+- `MessageIndex` クラスにC++の `mcap::MessageIndex` 構造体を参考に `ChannelId` (ushort), `Records` (List<Tuple<ulong, ulong>>) プロパティを実装しました。
+- `ChunkIndex` クラスにC++の `mcap::ChunkIndex` 構造体を参考に `MessageStartTime` (ulong), `MessageEndTime` (ulong), `ChunkStartOffset` (ulong), `ChunkLength` (ulong), `MessageIndexOffsets` (IReadOnlyDictionary<ushort, ulong>), `MessageIndexLength` (ulong), `Compression` (string), `CompressedSize` (ulong), `UncompressedSize` (ulong) プロパティを実装しました。
+- `Attachment` クラスにC++の `mcap::Attachment` 構造体を参考に `LogTime` (ulong), `CreateTime` (ulong), `Name` (string), `MediaType` (string), `Data` (byte[]), `Crc` (uint) プロパティを実装しました。
+- `AttachmentIndex` クラスにC++の `mcap::AttachmentIndex` 構造体を参考に `Offset` (ulong), `Length` (ulong), `LogTime` (ulong), `CreateTime` (ulong), `DataSize` (ulong), `Name` (string), `MediaType` (string) プロパティを実装しました。
+- `Statistics` クラスにC++の `mcap::Statistics` 構造体を参考に `MessageCount` (ulong), `SchemaCount` (ushort), `ChannelCount` (uint), `AttachmentCount` (uint), `MetadataCount` (uint), `ChunkCount` (uint), `MessageStartTime` (ulong), `MessageEndTime` (ulong), `ChannelMessageCounts` (IReadOnlyDictionary<ushort, ulong>) プロパティを実装しました。
+- `Metadata` クラスにC++の `mcap::Metadata` 構造体を参考に `Name` (string), `MetadataMap` (IReadOnlyDictionary<string, string>) プロパティを実装しました。
+- `MetadataIndex` クラスにC++の `mcap::MetadataIndex` 構造体を参考に `Offset` (ulong), `Length` (ulong), `Name` (string) プロパティを実装しました。
+- `SummaryOffset` クラスにC++の `mcap::SummaryOffset` 構造体を参考に `GroupOpCode` (OpCode), `GroupStart` (ulong), `GroupLength` (ulong) プロパティを実装しました。
+- `DataEnd` クラスにC++の `mcap::DataEnd` 構造体を参考に `DataSectionCrc` (uint) プロパティを実装しました。
+- 各プロパティに対応するテストを `RecordsTests.cs` に追加し、すべて成功することを確認しました。

--- a/csharp/Mcap.CSharp.Tests/RecordsTests.cs
+++ b/csharp/Mcap.CSharp.Tests/RecordsTests.cs
@@ -1,0 +1,397 @@
+using Mcap.CSharp.Mcap.Records;
+using Xunit;
+using Mcap.CSharp.Mcap;
+
+namespace Mcap.CSharp.Tests;
+
+public class RecordsTests
+{
+    [Fact]
+    public void CanCreateHeader()
+    {
+        var header = new Header();
+        Assert.NotNull(header);
+    }
+
+    [Fact]
+    public void Header_CanSetProperties()
+    {
+        var header = new Header
+        {
+            Profile = "test_profile",
+            Library = "test_library"
+        };
+        Assert.Equal("test_profile", header.Profile);
+        Assert.Equal("test_library", header.Library);
+    }
+
+    [Fact]
+    public void CanCreateFooter()
+    {
+        var footer = new Footer();
+        Assert.NotNull(footer);
+    }
+
+    [Fact]
+    public void Footer_CanSetProperties()
+    {
+        var footer = new Footer
+        {
+            SummaryStart = 100UL,
+            SummaryOffsetStart = 200UL,
+            SummaryCrc = 0x12345678U
+        };
+        Assert.Equal(100UL, footer.SummaryStart);
+        Assert.Equal(200UL, footer.SummaryOffsetStart);
+        Assert.Equal(0x12345678U, footer.SummaryCrc);
+    }
+
+    [Fact]
+    public void CanCreateSchema()
+    {
+        var schema = new Schema();
+        Assert.NotNull(schema);
+    }
+
+    [Fact]
+    public void Schema_CanSetProperties()
+    {
+        var schema = new Schema
+        {
+            Id = 1,
+            Name = "test_schema",
+            Encoding = "json",
+            Data = new byte[] { 0x01, 0x02, 0x03 }
+        };
+        Assert.Equal(1, schema.Id);
+        Assert.Equal("test_schema", schema.Name);
+        Assert.Equal("json", schema.Encoding);
+        Assert.Equal(new byte[] { 0x01, 0x02, 0x03 }, schema.Data);
+    }
+
+    [Fact]
+    public void CanCreateChannel()
+    {
+        var channel = new Channel();
+        Assert.NotNull(channel);
+    }
+
+    [Fact]
+    public void Channel_CanSetProperties()
+    {
+        var channel = new Channel
+        {
+            Id = 10,
+            Topic = "/test_topic",
+            MessageEncoding = "ros1",
+            SchemaId = 1,
+            Metadata = new Dictionary<string, string>
+            {
+                { "key1", "value1" },
+                { "key2", "value2" }
+            }
+        };
+        Assert.Equal(10, channel.Id);
+        Assert.Equal("/test_topic", channel.Topic);
+        Assert.Equal("ros1", channel.MessageEncoding);
+        Assert.Equal(1, channel.SchemaId);
+        Assert.Equal("value1", channel.Metadata["key1"]);
+        Assert.Equal("value2", channel.Metadata["key2"]);
+    }
+
+    [Fact]
+    public void CanCreateMessage()
+    {
+        var message = new Message();
+        Assert.NotNull(message);
+    }
+
+    [Fact]
+    public void Message_CanSetProperties()
+    {
+        var message = new Message
+        {
+            ChannelId = 100,
+            Sequence = 1,
+            LogTime = 1234567890123456789UL,
+            PublishTime = 9876543210987654321UL,
+            Data = new byte[] { 0x04, 0x05, 0x06 }
+        };
+        Assert.Equal(100, message.ChannelId);
+        Assert.Equal(1U, message.Sequence);
+        Assert.Equal(1234567890123456789UL, message.LogTime);
+        Assert.Equal(9876543210987654321UL, message.PublishTime);
+        Assert.Equal(new byte[] { 0x04, 0x05, 0x06 }, message.Data);
+    }
+
+    [Fact]
+    public void CanCreateChunk()
+    {
+        var chunk = new Chunk();
+        Assert.NotNull(chunk);
+    }
+
+    [Fact]
+    public void Chunk_CanSetProperties()
+    {
+        var chunk = new Chunk
+        {
+            MessageStartTime = 1000UL,
+            MessageEndTime = 2000UL,
+            UncompressedSize = 500UL,
+            UncompressedCrc = 0xABCDEF01U,
+            Compression = "lz4",
+            CompressedSize = 300UL,
+            Records = new byte[] { 0x07, 0x08, 0x09 }
+        };
+        Assert.Equal(1000UL, chunk.MessageStartTime);
+        Assert.Equal(2000UL, chunk.MessageEndTime);
+        Assert.Equal(500UL, chunk.UncompressedSize);
+        Assert.Equal(0xABCDEF01U, chunk.UncompressedCrc);
+        Assert.Equal("lz4", chunk.Compression);
+        Assert.Equal(300UL, chunk.CompressedSize);
+        Assert.Equal(new byte[] { 0x07, 0x08, 0x09 }, chunk.Records);
+    }
+
+    [Fact]
+    public void CanCreateMessageIndex()
+    {
+        var messageIndex = new MessageIndex();
+        Assert.NotNull(messageIndex);
+    }
+
+    [Fact]
+    public void MessageIndex_CanSetProperties()
+    {
+        var messageIndex = new MessageIndex
+        {
+            ChannelId = 1,
+            Records = new List<Tuple<ulong, ulong>>
+            {
+                Tuple.Create(100UL, 10UL),
+                Tuple.Create(200UL, 20UL)
+            }
+        };
+        Assert.Equal(1, messageIndex.ChannelId);
+        Assert.Equal(2, messageIndex.Records.Count);
+        Assert.Equal(100UL, messageIndex.Records[0].Item1);
+        Assert.Equal(10UL, messageIndex.Records[0].Item2);
+        Assert.Equal(200UL, messageIndex.Records[1].Item1);
+        Assert.Equal(20UL, messageIndex.Records[1].Item2);
+    }
+
+    [Fact]
+    public void CanCreateChunkIndex()
+    {
+        var chunkIndex = new ChunkIndex();
+        Assert.NotNull(chunkIndex);
+    }
+
+    [Fact]
+    public void ChunkIndex_CanSetProperties()
+    {
+        var chunkIndex = new ChunkIndex
+        {
+            MessageStartTime = 1000UL,
+            MessageEndTime = 2000UL,
+            ChunkStartOffset = 100UL,
+            ChunkLength = 500UL,
+            MessageIndexOffsets = new Dictionary<ushort, ulong>
+            {
+                { 1, 10UL },
+                { 2, 20UL }
+            },
+            MessageIndexLength = 30UL,
+            Compression = "zstd",
+            CompressedSize = 400UL,
+            UncompressedSize = 600UL
+        };
+        Assert.Equal(1000UL, chunkIndex.MessageStartTime);
+        Assert.Equal(2000UL, chunkIndex.MessageEndTime);
+        Assert.Equal(100UL, chunkIndex.ChunkStartOffset);
+        Assert.Equal(500UL, chunkIndex.ChunkLength);
+        Assert.Equal(10UL, chunkIndex.MessageIndexOffsets[1]);
+        Assert.Equal(20UL, chunkIndex.MessageIndexOffsets[2]);
+        Assert.Equal(30UL, chunkIndex.MessageIndexLength);
+        Assert.Equal("zstd", chunkIndex.Compression);
+        Assert.Equal(400UL, chunkIndex.CompressedSize);
+        Assert.Equal(600UL, chunkIndex.UncompressedSize);
+    }
+
+    [Fact]
+    public void CanCreateAttachment()
+    {
+        var attachment = new Attachment();
+        Assert.NotNull(attachment);
+    }
+
+    [Fact]
+    public void Attachment_CanSetProperties()
+    {
+        var attachment = new Attachment
+        {
+            LogTime = 1000UL,
+            CreateTime = 2000UL,
+            Name = "test_attachment.txt",
+            MediaType = "text/plain",
+            Data = new byte[] { 0x01, 0x02, 0x03 },
+            Crc = 0xABCDEF01U
+        };
+        Assert.Equal(1000UL, attachment.LogTime);
+        Assert.Equal(2000UL, attachment.CreateTime);
+        Assert.Equal("test_attachment.txt", attachment.Name);
+        Assert.Equal("text/plain", attachment.MediaType);
+        Assert.Equal(new byte[] { 0x01, 0x02, 0x03 }, attachment.Data);
+        Assert.Equal(0xABCDEF01U, attachment.Crc);
+    }
+
+    [Fact]
+    public void CanCreateAttachmentIndex()
+    {
+        var attachmentIndex = new AttachmentIndex();
+        Assert.NotNull(attachmentIndex);
+    }
+
+    [Fact]
+    public void AttachmentIndex_CanSetProperties()
+    {
+        var attachmentIndex = new AttachmentIndex
+        {
+            Offset = 100UL,
+            Length = 200UL,
+            LogTime = 1000UL,
+            CreateTime = 2000UL,
+            DataSize = 500UL,
+            Name = "test_attachment_index.txt",
+            MediaType = "text/plain"
+        };
+        Assert.Equal(100UL, attachmentIndex.Offset);
+        Assert.Equal(200UL, attachmentIndex.Length);
+        Assert.Equal(1000UL, attachmentIndex.LogTime);
+        Assert.Equal(2000UL, attachmentIndex.CreateTime);
+        Assert.Equal(500UL, attachmentIndex.DataSize);
+        Assert.Equal("test_attachment_index.txt", attachmentIndex.Name);
+        Assert.Equal("text/plain", attachmentIndex.MediaType);
+    }
+
+    [Fact]
+    public void CanCreateStatistics()
+    {
+        var statistics = new Statistics();
+        Assert.NotNull(statistics);
+    }
+
+    [Fact]
+    public void Statistics_CanSetProperties()
+    {
+        var statistics = new Statistics
+        {
+            MessageCount = 100UL,
+            SchemaCount = 10,
+            ChannelCount = 20,
+            AttachmentCount = 5,
+            MetadataCount = 3,
+            ChunkCount = 2,
+            MessageStartTime = 1000UL,
+            MessageEndTime = 2000UL,
+            ChannelMessageCounts = new Dictionary<ushort, ulong>
+            {
+                { 1, 50UL },
+                { 2, 50UL }
+            }
+        };
+        Assert.Equal(100UL, statistics.MessageCount);
+        Assert.Equal(10, statistics.SchemaCount);
+        Assert.Equal(20U, statistics.ChannelCount);
+        Assert.Equal(5U, statistics.AttachmentCount);
+        Assert.Equal(3U, statistics.MetadataCount);
+        Assert.Equal(2U, statistics.ChunkCount);
+        Assert.Equal(1000UL, statistics.MessageStartTime);
+        Assert.Equal(2000UL, statistics.MessageEndTime);
+        Assert.Equal(50UL, statistics.ChannelMessageCounts[1]);
+        Assert.Equal(50UL, statistics.ChannelMessageCounts[2]);
+    }
+
+    [Fact]
+    public void CanCreateMetadata()
+    {
+        var metadata = new Metadata();
+        Assert.NotNull(metadata);
+    }
+
+    [Fact]
+    public void Metadata_CanSetProperties()
+    {
+        var metadata = new Metadata
+        {
+            Name = "test_metadata",
+            MetadataMap = new Dictionary<string, string>
+            {
+                { "keyA", "valueA" },
+                { "keyB", "valueB" }
+            }
+        };
+        Assert.Equal("test_metadata", metadata.Name);
+        Assert.Equal("valueA", metadata.MetadataMap["keyA"]);
+        Assert.Equal("valueB", metadata.MetadataMap["keyB"]);
+    }
+
+    [Fact]
+    public void CanCreateMetadataIndex()
+    {
+        var metadataIndex = new MetadataIndex();
+        Assert.NotNull(metadataIndex);
+    }
+
+    [Fact]
+    public void MetadataIndex_CanSetProperties()
+    {
+        var metadataIndex = new MetadataIndex
+        {
+            Offset = 100UL,
+            Length = 200UL,
+            Name = "test_metadata_index"
+        };
+        Assert.Equal(100UL, metadataIndex.Offset);
+        Assert.Equal(200UL, metadataIndex.Length);
+        Assert.Equal("test_metadata_index", metadataIndex.Name);
+    }
+
+    [Fact]
+    public void CanCreateSummaryOffset()
+    {
+        var summaryOffset = new SummaryOffset();
+        Assert.NotNull(summaryOffset);
+    }
+
+    [Fact]
+    public void SummaryOffset_CanSetProperties()
+    {
+        var summaryOffset = new SummaryOffset
+        {
+            GroupOpCode = OpCode.Schema,
+            GroupStart = 100UL,
+            GroupLength = 200UL
+        };
+        Assert.Equal(OpCode.Schema, summaryOffset.GroupOpCode);
+        Assert.Equal(100UL, summaryOffset.GroupStart);
+        Assert.Equal(200UL, summaryOffset.GroupLength);
+    }
+
+    [Fact]
+    public void CanCreateDataEnd()
+    {
+        var dataEnd = new DataEnd();
+        Assert.NotNull(dataEnd);
+    }
+
+    [Fact]
+    public void DataEnd_CanSetProperties()
+    {
+        var dataEnd = new DataEnd
+        {
+            DataSectionCrc = 0xABCDEF01U
+        };
+        Assert.Equal(0xABCDEF01U, dataEnd.DataSectionCrc);
+    }
+}

--- a/csharp/Mcap.CSharp/Mcap/Records/Attachment.cs
+++ b/csharp/Mcap.CSharp/Mcap/Records/Attachment.cs
@@ -1,0 +1,14 @@
+namespace Mcap.CSharp.Mcap.Records;
+
+/// <summary>
+/// Corresponds to the C++ `mcap::Attachment` struct.
+/// </summary>
+public class Attachment
+{
+    public ulong LogTime { get; set; }
+    public ulong CreateTime { get; set; }
+    public string Name { get; set; } = "";
+    public string MediaType { get; set; } = "";
+    public byte[] Data { get; set; } = Array.Empty<byte>();
+    public uint Crc { get; set; }
+}

--- a/csharp/Mcap.CSharp/Mcap/Records/AttachmentIndex.cs
+++ b/csharp/Mcap.CSharp/Mcap/Records/AttachmentIndex.cs
@@ -1,0 +1,15 @@
+namespace Mcap.CSharp.Mcap.Records;
+
+/// <summary>
+/// Corresponds to the C++ `mcap::AttachmentIndex` struct.
+/// </summary>
+public class AttachmentIndex
+{
+    public ulong Offset { get; set; }
+    public ulong Length { get; set; }
+    public ulong LogTime { get; set; }
+    public ulong CreateTime { get; set; }
+    public ulong DataSize { get; set; }
+    public string Name { get; set; } = "";
+    public string MediaType { get; set; } = "";
+}

--- a/csharp/Mcap.CSharp/Mcap/Records/Channel.cs
+++ b/csharp/Mcap.CSharp/Mcap/Records/Channel.cs
@@ -1,0 +1,13 @@
+namespace Mcap.CSharp.Mcap.Records;
+
+/// <summary>
+/// Corresponds to the C++ `mcap::Channel` struct.
+/// </summary>
+public class Channel
+{
+    public ushort Id { get; set; }
+    public string Topic { get; set; } = "";
+    public string MessageEncoding { get; set; } = "";
+    public ushort SchemaId { get; set; }
+    public IReadOnlyDictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
+}

--- a/csharp/Mcap.CSharp/Mcap/Records/Chunk.cs
+++ b/csharp/Mcap.CSharp/Mcap/Records/Chunk.cs
@@ -1,0 +1,15 @@
+namespace Mcap.CSharp.Mcap.Records;
+
+/// <summary>
+/// Corresponds to the C++ `mcap::Chunk` struct.
+/// </summary>
+public class Chunk
+{
+    public ulong MessageStartTime { get; set; }
+    public ulong MessageEndTime { get; set; }
+    public ulong UncompressedSize { get; set; }
+    public uint UncompressedCrc { get; set; }
+    public string Compression { get; set; } = "";
+    public ulong CompressedSize { get; set; }
+    public byte[] Records { get; set; } = Array.Empty<byte>();
+}

--- a/csharp/Mcap.CSharp/Mcap/Records/ChunkIndex.cs
+++ b/csharp/Mcap.CSharp/Mcap/Records/ChunkIndex.cs
@@ -1,0 +1,17 @@
+namespace Mcap.CSharp.Mcap.Records;
+
+/// <summary>
+/// Corresponds to the C++ `mcap::ChunkIndex` struct.
+/// </summary>
+public class ChunkIndex
+{
+    public ulong MessageStartTime { get; set; }
+    public ulong MessageEndTime { get; set; }
+    public ulong ChunkStartOffset { get; set; }
+    public ulong ChunkLength { get; set; }
+    public IReadOnlyDictionary<ushort, ulong> MessageIndexOffsets { get; set; } = new Dictionary<ushort, ulong>();
+    public ulong MessageIndexLength { get; set; }
+    public string Compression { get; set; } = "";
+    public ulong CompressedSize { get; set; }
+    public ulong UncompressedSize { get; set; }
+}

--- a/csharp/Mcap.CSharp/Mcap/Records/DataEnd.cs
+++ b/csharp/Mcap.CSharp/Mcap/Records/DataEnd.cs
@@ -1,0 +1,9 @@
+namespace Mcap.CSharp.Mcap.Records;
+
+/// <summary>
+/// Corresponds to the C++ `mcap::DataEnd` struct.
+/// </summary>
+public class DataEnd
+{
+    public uint DataSectionCrc { get; set; }
+}

--- a/csharp/Mcap.CSharp/Mcap/Records/Footer.cs
+++ b/csharp/Mcap.CSharp/Mcap/Records/Footer.cs
@@ -1,0 +1,11 @@
+namespace Mcap.CSharp.Mcap.Records;
+
+/// <summary>
+/// Corresponds to the C++ `mcap::Footer` struct.
+/// </summary>
+public class Footer
+{
+    public ulong SummaryStart { get; set; }
+    public ulong SummaryOffsetStart { get; set; }
+    public uint SummaryCrc { get; set; }
+}

--- a/csharp/Mcap.CSharp/Mcap/Records/Header.cs
+++ b/csharp/Mcap.CSharp/Mcap/Records/Header.cs
@@ -1,0 +1,10 @@
+namespace Mcap.CSharp.Mcap.Records;
+
+/// <summary>
+/// Corresponds to the C++ `mcap::Header` struct.
+/// </summary>
+public class Header
+{
+    public string Profile { get; set; } = "";
+    public string Library { get; set; } = "";
+}

--- a/csharp/Mcap.CSharp/Mcap/Records/Message.cs
+++ b/csharp/Mcap.CSharp/Mcap/Records/Message.cs
@@ -1,0 +1,13 @@
+namespace Mcap.CSharp.Mcap.Records;
+
+/// <summary>
+/// Corresponds to the C++ `mcap::Message` struct.
+/// </summary>
+public class Message
+{
+    public ushort ChannelId { get; set; }
+    public uint Sequence { get; set; }
+    public ulong LogTime { get; set; }
+    public ulong PublishTime { get; set; }
+    public byte[] Data { get; set; } = Array.Empty<byte>();
+}

--- a/csharp/Mcap.CSharp/Mcap/Records/MessageIndex.cs
+++ b/csharp/Mcap.CSharp/Mcap/Records/MessageIndex.cs
@@ -1,0 +1,10 @@
+namespace Mcap.CSharp.Mcap.Records;
+
+/// <summary>
+/// Corresponds to the C++ `mcap::MessageIndex` struct.
+/// </summary>
+public class MessageIndex
+{
+    public ushort ChannelId { get; set; }
+    public List<Tuple<ulong, ulong>> Records { get; set; } = new List<Tuple<ulong, ulong>>();
+}

--- a/csharp/Mcap.CSharp/Mcap/Records/Metadata.cs
+++ b/csharp/Mcap.CSharp/Mcap/Records/Metadata.cs
@@ -1,0 +1,10 @@
+namespace Mcap.CSharp.Mcap.Records;
+
+/// <summary>
+/// Corresponds to the C++ `mcap::Metadata` struct.
+/// </summary>
+public class Metadata
+{
+    public string Name { get; set; } = "";
+    public IReadOnlyDictionary<string, string> MetadataMap { get; set; } = new Dictionary<string, string>();
+}

--- a/csharp/Mcap.CSharp/Mcap/Records/MetadataIndex.cs
+++ b/csharp/Mcap.CSharp/Mcap/Records/MetadataIndex.cs
@@ -1,0 +1,11 @@
+namespace Mcap.CSharp.Mcap.Records;
+
+/// <summary>
+/// Corresponds to the C++ `mcap::MetadataIndex` struct.
+/// </summary>
+public class MetadataIndex
+{
+    public ulong Offset { get; set; }
+    public ulong Length { get; set; }
+    public string Name { get; set; } = "";
+}

--- a/csharp/Mcap.CSharp/Mcap/Records/Schema.cs
+++ b/csharp/Mcap.CSharp/Mcap/Records/Schema.cs
@@ -1,0 +1,12 @@
+namespace Mcap.CSharp.Mcap.Records;
+
+/// <summary>
+/// Corresponds to the C++ `mcap::Schema` struct.
+/// </summary>
+public class Schema
+{
+    public ushort Id { get; set; }
+    public string Name { get; set; } = "";
+    public string Encoding { get; set; } = "";
+    public byte[] Data { get; set; } = Array.Empty<byte>();
+}

--- a/csharp/Mcap.CSharp/Mcap/Records/Statistics.cs
+++ b/csharp/Mcap.CSharp/Mcap/Records/Statistics.cs
@@ -1,0 +1,17 @@
+namespace Mcap.CSharp.Mcap.Records;
+
+/// <summary>
+/// Corresponds to the C++ `mcap::Statistics` struct.
+/// </summary>
+public class Statistics
+{
+    public ulong MessageCount { get; set; }
+    public ushort SchemaCount { get; set; }
+    public uint ChannelCount { get; set; }
+    public uint AttachmentCount { get; set; }
+    public uint MetadataCount { get; set; }
+    public uint ChunkCount { get; set; }
+    public ulong MessageStartTime { get; set; }
+    public ulong MessageEndTime { get; set; }
+    public IReadOnlyDictionary<ushort, ulong> ChannelMessageCounts { get; set; } = new Dictionary<ushort, ulong>();
+}

--- a/csharp/Mcap.CSharp/Mcap/Records/SummaryOffset.cs
+++ b/csharp/Mcap.CSharp/Mcap/Records/SummaryOffset.cs
@@ -1,0 +1,11 @@
+namespace Mcap.CSharp.Mcap.Records;
+
+/// <summary>
+/// Corresponds to the C++ `mcap::SummaryOffset` struct.
+/// </summary>
+public class SummaryOffset
+{
+    public OpCode GroupOpCode { get; set; }
+    public ulong GroupStart { get; set; }
+    public ulong GroupLength { get; set; }
+}


### PR DESCRIPTION
このプルリクエストは、C# MCAPライブラリ移植計画の「タスク 1.3: データモデルのクラス実装」を完了します。

主な変更点:
- `Records/` ディレクトリを作成し、すべてのMCAPレコードに対応するC#クラスファイルを作成しました。
- 各クラスの定義に、移植元であるC++の構造体名をコメントとして追記しました。
- TDDに基づき、`Header`, `Footer`, `Schema`, `Channel`, `Message`, `Chunk`, `MessageIndex`, `ChunkIndex`, `Attachment`, `AttachmentIndex`, `Statistics`, `Metadata`, `MetadataIndex`, `SummaryOffset`, `DataEnd` クラスのプロパティを実装し、テストが成功することを確認しました。
- `task_1.3_implement_data_models.md` に作業状況を追記しました。
- 対応済みのサブIssueをクローズしました。

関連Issue: #4